### PR TITLE
Fix "DeprecationWarning: Invalid 'main' field"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "README.md",
         "telnet-stream.d.ts"
     ],
-    "main": "telnet-stream",
+    "main": "index.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/blinkdog/telnet-stream.git"


### PR DESCRIPTION
Hey, thanks for the rad library! I was getting a deprecation warning and it looks like an easy fix.

```node --trace-deprecation node_modules/telnet-stream
(node:60726) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/.../node_modules/telnet-stream/package.json' of 'telnet-stream'. Please either fix that or report it to the module author
    at tryPackage (node:internal/modules/cjs/loader:364:15)
    at Function.Module._findPath (node:internal/modules/cjs/loader:566:18)
    at resolveMainPath (node:internal/modules/run_main:15:25)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:75:24)
    at node:internal/main/run_main_module:17:47```